### PR TITLE
Add enhanced nuspec elements

### DIFF
--- a/gocd-agent/agent.nuspec
+++ b/gocd-agent/agent.nuspec
@@ -21,7 +21,7 @@ These parameters can be passed to the installer with the use of `--ia`.
     </description>
     <projectUrl>https://gocd.io/</projectUrl>
     <docsUrl>https://docs.gocd.io</docsUrl>
-    <mailingListUrl>https://www.gocd.io/subscribe/</mailingListUrl>
+    <mailingListUrl>https://groups.google.com/forum/#!forum/go-cd</mailingListUrl>
     <bugTrackerUrl>https://github.com/gocd/gocd/issues</bugTrackerUrl>
     <projectSourceUrl>https://github.com/gocd/gocd</projectSourceUrl>
     <packageSourceUrl>https://github.com/gocd/gocd-chocolatey</packageSourceUrl>

--- a/gocd-agent/agent.nuspec
+++ b/gocd-agent/agent.nuspec
@@ -19,7 +19,7 @@ The following install arguments can be set:
 
 These parameters can be passed to the installer with the use of `--ia`.
     </description>
-    <projectUrl>https://gocd.io/</projectUrl>
+    <projectUrl>https://gocd.io</projectUrl>
     <docsUrl>https://docs.gocd.io</docsUrl>
     <mailingListUrl>https://groups.google.com/forum/#!forum/go-cd</mailingListUrl>
     <bugTrackerUrl>https://github.com/gocd/gocd/issues</bugTrackerUrl>

--- a/gocd-agent/agent.nuspec
+++ b/gocd-agent/agent.nuspec
@@ -20,6 +20,11 @@ The following install arguments can be set:
 These parameters can be passed to the installer with the use of `--ia`.
     </description>
     <projectUrl>https://gocd.io/</projectUrl>
+    <docsUrl>https://docs.gocd.io</docsUrl>
+    <mailingListUrl>https://www.gocd.io/subscribe/</mailingListUrl>
+    <bugTrackerUrl>https://github.com/gocd/gocd/issues</bugTrackerUrl>
+    <projectSourceUrl>https://github.com/gocd/gocd</projectSourceUrl>
+    <packageSourceUrl>https://github.com/gocd/gocd-chocolatey</packageSourceUrl>
     <tags>gocd cd continuous-delivery admin</tags>
     <copyright>Copyright 2017 ThoughtWorks, Inc.</copyright>
     <licenseUrl>https://www.apache.org/licenses/LICENSE-2.0</licenseUrl>

--- a/gocd-server/server.nuspec
+++ b/gocd-server/server.nuspec
@@ -20,7 +20,7 @@ These parameters can be passed to the installer with the use of `--ia`.
     </description>
     <projectUrl>https://gocd.io/</projectUrl>
     <docsUrl>https://docs.gocd.io</docsUrl>
-    <mailingListUrl>https://www.gocd.io/subscribe/</mailingListUrl>
+    <mailingListUrl>https://groups.google.com/forum/#!forum/go-cd</mailingListUrl>
     <bugTrackerUrl>https://github.com/gocd/gocd/issues</bugTrackerUrl>
     <projectSourceUrl>https://github.com/gocd/gocd</projectSourceUrl>
     <packageSourceUrl>https://github.com/gocd/gocd-chocolatey</packageSourceUrl>

--- a/gocd-server/server.nuspec
+++ b/gocd-server/server.nuspec
@@ -19,6 +19,11 @@ The following install arguments can be set:
 These parameters can be passed to the installer with the use of `--ia`.
     </description>
     <projectUrl>https://gocd.io/</projectUrl>
+    <docsUrl>https://docs.gocd.io</docsUrl>
+    <mailingListUrl>https://www.gocd.io/subscribe/</mailingListUrl>
+    <bugTrackerUrl>https://github.com/gocd/gocd/issues</bugTrackerUrl>
+    <projectSourceUrl>https://github.com/gocd/gocd</projectSourceUrl>
+    <packageSourceUrl>https://github.com/gocd/gocd-chocolatey</packageSourceUrl>
     <tags>gocd cd continuous-delivery admin</tags>
     <copyright>Copyright 2017 ThoughtWorks, Inc.</copyright>
     <licenseUrl>https://www.apache.org/licenses/LICENSE-2.0</licenseUrl>

--- a/gocd-server/server.nuspec
+++ b/gocd-server/server.nuspec
@@ -18,7 +18,7 @@ The following install arguments can be set:
 
 These parameters can be passed to the installer with the use of `--ia`.
     </description>
-    <projectUrl>https://gocd.io/</projectUrl>
+    <projectUrl>https://gocd.io</projectUrl>
     <docsUrl>https://docs.gocd.io</docsUrl>
     <mailingListUrl>https://groups.google.com/forum/#!forum/go-cd</mailingListUrl>
     <bugTrackerUrl>https://github.com/gocd/gocd/issues</bugTrackerUrl>


### PR DESCRIPTION
The latest version of GoCdAgent (17.4.0) is awaiting validation with some warnings.

The package generation scripts have already been updated to include a checksum, which was the primary issue with the package, but there are a few other suggestions that don't appear to have been addressed yet.

The suggestions are described on this page in the Chocolatey docs: https://github.com/chocolatey/package-validator/wiki/NuspecEnhancementsMissing

This PR adds  my best guesses at the correct values. The two values I'm least sure of are:
* The docs URL. Should it point to the specific version in the package (ie, https://docs.gocd.io/17.4.0/) or should it point to the latest docs?
* The mailing list URL. Should it point directly to the Google group?

Please let me know if you'd like me to change anything.