### PR TITLE
Read from the version json file if no environment variable is specified.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 *.nupkg
+.idea/

--- a/createPackage.ps1
+++ b/createPackage.ps1
@@ -46,6 +46,13 @@ param(
 )
 
 $path = "gocd-$type"
+
+If ((-Not $version) -and (-Not $revision)) {
+    $json = (Get-Content ..\version.json) | Out-String | ConvertFrom-Json
+    $version = $json.go_version
+    $revision = $json.go_build_number
+}
+
 $fullVersion = "$version-$revision"
 
 Push-Location $path


### PR DESCRIPTION
* This is useful for the CI when we can fetch the version.json file as an artifact from upstream and parse the contents.