### PR TITLE
Remove packaging 32bit installer as its no longer available.

### DIFF
--- a/createPackage.ps1
+++ b/createPackage.ps1
@@ -57,10 +57,9 @@ $fullVersion = "$version-$revision"
 
 Push-Location $path
 
-$checksum32 = (New-Object System.Net.WebClient).DownloadString("https://download.gocd.org/binaries/$fullVersion/win/go-$type-$fullVersion-jre-32bit-setup.exe.sha256sum").Split(' ')[0]
 $checksum64 = (New-Object System.Net.WebClient).DownloadString("https://download.gocd.org/binaries/$fullVersion/win/go-$type-$fullVersion-jre-64bit-setup.exe.sha256sum").Split(' ')[0]
 
-(Get-Content tools\chocolateyInstall.ps1.template) -replace '{{fullVersion}}', $fullVersion -replace '{{checksum-32bit}}', $checksum32 -replace '{{checksum-64bit}}', $checksum64 | out-file tools\chocolateyInstall.ps1;
+(Get-Content tools\chocolateyInstall.ps1.template) -replace '{{fullVersion}}', $fullVersion -replace '{{checksum-64bit}}', $checksum64 | out-file tools\chocolateyInstall.ps1;
 choco pack --version=$version
 
 Pop-Location

--- a/gocd-agent/tools/chocolateyInstall.ps1.template
+++ b/gocd-agent/tools/chocolateyInstall.ps1.template
@@ -2,10 +2,6 @@ $packageArgs = @{
     packageName        = 'gocdagent'
     installerType      = 'exe'
 
-    url                = 'https://download.gocd.org/binaries/{{fullVersion}}/win/go-agent-{{fullVersion}}-jre-32bit-setup.exe'
-    checksumType       = 'sha256'
-    checksum           = '{{checksum-32bit}}'
-
     url64              = 'https://download.gocd.org/binaries/{{fullVersion}}/win/go-agent-{{fullVersion}}-jre-64bit-setup.exe'
     checksumType64     = 'sha256'
     checksum64         = '{{checksum-64bit}}'

--- a/gocd-server/tools/chocolateyInstall.ps1.template
+++ b/gocd-server/tools/chocolateyInstall.ps1.template
@@ -2,10 +2,6 @@ $packageArgs = @{
     packageName        = 'gocdserver'
     installerType      = 'exe'
 
-    url                = 'https://download.gocd.org/binaries/{{fullVersion}}/win/go-server-{{fullVersion}}-jre-32bit-setup.exe'
-    checksumType       = 'sha256'
-    checksum           = '{{checksum-32bit}}'
-
     url64              = 'https://download.gocd.org/binaries/{{fullVersion}}/win/go-server-{{fullVersion}}-jre-64bit-setup.exe'
     checksumType64     = 'sha256'
     checksum64         = '{{checksum-64bit}}'


### PR DESCRIPTION
https://chocolatey.org/docs/helpers-install-chocolatey-package

The -Url arg section says:  
"If there is only a 64 bit url
available, please remove do not use the parameter (only use Url64bit).
Will fail on 32bit systems if missing or if a user attempts to force
a 32 bit installation on a 64 bit system." 